### PR TITLE
Add generic `Menu` components for standard treatment

### DIFF
--- a/portal/src/components/game_console/lib/MenuLink.tsx
+++ b/portal/src/components/game_console/lib/MenuLink.tsx
@@ -1,0 +1,12 @@
+import { PropsWithChildren } from 'react';
+
+interface MenuLinkProps {
+  onClick: () => void;
+}
+
+export default function MenuLink({
+  onClick,
+  children,
+}: PropsWithChildren<MenuLinkProps>) {
+  return <button onClick={onClick}>{children}</button>;
+}

--- a/portal/src/components/game_console/lib/MenuList.tsx
+++ b/portal/src/components/game_console/lib/MenuList.tsx
@@ -5,16 +5,15 @@ import { FaPlay } from 'react-icons/fa';
 interface MenuListProps {
   withCursor?: boolean;
   layout?: 'default' | 'grid';
-  columns?: number;
 }
 
 export default function MenuList({
   withCursor = true,
   layout = 'default',
-  columns = 4,
   children,
 }: PropsWithChildren<MenuListProps>) {
   const [cursorPosition, setCursorPosition] = useState(0);
+  const columns = window.innerWidth > 768 ? '4' : '2';
   const containerClasses =
     layout === 'default' ? '' : `grid grid-cols-${columns} gap-y-4`;
 

--- a/portal/src/components/game_console/lib/MenuList.tsx
+++ b/portal/src/components/game_console/lib/MenuList.tsx
@@ -1,0 +1,62 @@
+import { DownKeys, UpKeys } from '@/types/keys';
+import { Children, PropsWithChildren, useEffect, useState } from 'react';
+import { FaPlay } from 'react-icons/fa';
+
+interface MenuListProps {
+  withCursor?: boolean;
+  layout?: 'default' | 'grid';
+  columns?: number;
+}
+
+export default function MenuList({
+  withCursor = true,
+  layout = 'default',
+  columns = 4,
+  children,
+}: PropsWithChildren<MenuListProps>) {
+  const [cursorPosition, setCursorPosition] = useState(0);
+  const containerClasses =
+    layout === 'default' ? '' : `grid grid-cols-${columns} gap-y-4`;
+
+  useEffect(() => {
+    function arrowHandler(event: KeyboardEvent) {
+      if (UpKeys.includes(event.key)) {
+        setCursorPosition((cursorPosition) => Math.max(0, cursorPosition - 1));
+      }
+      if (DownKeys.includes(event.key)) {
+        setCursorPosition((cursorPosition) =>
+          Math.min(Children.count(children) - 1, cursorPosition + 1)
+        );
+      }
+    }
+
+    window.addEventListener('keydown', arrowHandler);
+    return () => {
+      window.removeEventListener('keydown', arrowHandler);
+    };
+  }, [children]);
+
+  function handleMouseEnter(position: number) {
+    if (withCursor) {
+      setCursorPosition(position);
+    }
+  }
+
+  return (
+    <ul className={containerClasses}>
+      {Children.map(children, (child, index) => (
+        <li tabIndex={-1} id={'select'}>
+          <div
+            className='flex items-center'
+            onMouseEnter={() => handleMouseEnter(index)}
+          >
+            {withCursor && cursorPosition === index && (
+              <FaPlay className='mr-2' />
+            )}
+            {child}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/portal/src/components/game_console/lib/MenuList.tsx
+++ b/portal/src/components/game_console/lib/MenuList.tsx
@@ -5,14 +5,17 @@ import { FaPlay } from 'react-icons/fa';
 interface MenuListProps {
   withCursor?: boolean;
   layout?: 'default' | 'grid';
+  itemGap?: string;
 }
 
 export default function MenuList({
   withCursor = true,
   layout = 'default',
+  itemGap,
   children,
 }: PropsWithChildren<MenuListProps>) {
   const [cursorPosition, setCursorPosition] = useState(0);
+  const gap = itemGap ? `mt-${itemGap}` : '';
   const columns = window.innerWidth > 768 ? '4' : '2';
   const containerClasses =
     layout === 'default' ? '' : `grid grid-cols-${columns} gap-y-4`;
@@ -46,11 +49,14 @@ export default function MenuList({
       {Children.map(children, (child, index) => (
         <li tabIndex={-1}>
           <div
-            className='flex items-center'
+            className={`flex items-center ${index > 0 ? gap : ''}`}
             onMouseEnter={() => handleMouseEnter(index)}
           >
             {withCursor && cursorPosition === index && (
-              <FaPlay className='mr-2' />
+              <FaPlay className='mr-1' />
+            )}
+            {withCursor && cursorPosition !== index && (
+              <span style={{ width: 16 }} className='mr-1'></span>
             )}
             {child}
           </div>

--- a/portal/src/components/game_console/lib/MenuList.tsx
+++ b/portal/src/components/game_console/lib/MenuList.tsx
@@ -45,7 +45,7 @@ export default function MenuList({
   return (
     <ul className={containerClasses}>
       {Children.map(children, (child, index) => (
-        <li tabIndex={-1} id={'select'}>
+        <li tabIndex={-1}>
           <div
             className='flex items-center'
             onMouseEnter={() => handleMouseEnter(index)}

--- a/portal/src/components/game_console/lib/MenuPage.tsx
+++ b/portal/src/components/game_console/lib/MenuPage.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren } from 'react';
+import MenuLink from './MenuLink';
+
+interface MenuPageProps {
+  title: JSX.Element | string;
+  onBack: () => void;
+}
+
+export default function MenuPage({
+  title,
+  onBack,
+  children,
+}: PropsWithChildren<MenuPageProps>) {
+  return (
+    <div>
+      <div>{title}</div>
+      <div>{children}</div>
+      <MenuLink onClick={onBack}>Back</MenuLink>
+    </div>
+  );
+}

--- a/portal/src/components/game_console/menus/bedroom/BedroomInput.tsx
+++ b/portal/src/components/game_console/menus/bedroom/BedroomInput.tsx
@@ -1,5 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
-import MenuLink from '../../lib/MenuLink';
+import MenuPage from '../../lib/MenuPage';
 
 export default function BedroomInput() {
   const { updateMenu } = useScreenStore();
@@ -8,10 +8,5 @@ export default function BedroomInput() {
     updateMenu('Bedroom Menu');
   }
 
-  return (
-    <div>
-      <div>Input Your Info</div>
-      <MenuLink onClick={handleBack}>Back</MenuLink>
-    </div>
-  );
+  return <MenuPage title='Input Your Info' onBack={handleBack}></MenuPage>;
 }

--- a/portal/src/components/game_console/menus/bedroom/BedroomInput.tsx
+++ b/portal/src/components/game_console/menus/bedroom/BedroomInput.tsx
@@ -1,4 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
+import MenuLink from '../../lib/MenuLink';
 
 export default function BedroomInput() {
   const { updateMenu } = useScreenStore();
@@ -10,9 +11,7 @@ export default function BedroomInput() {
   return (
     <div>
       <div>Input Your Info</div>
-      <div className='cursor-pointer' onClick={handleBack}>
-        Back
-      </div>
+      <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );
 }

--- a/portal/src/components/game_console/menus/bedroom/BedroomMenu.tsx
+++ b/portal/src/components/game_console/menus/bedroom/BedroomMenu.tsx
@@ -1,4 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
+import MenuLink from '../../lib/MenuLink';
 
 export default function BedroomMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -11,9 +12,7 @@ export default function BedroomMenu() {
   return (
     <div>
       <div>Bedroom</div>
-      <div className='cursor-pointer' onClick={handleBack}>
-        Back
-      </div>
+      <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );
 }

--- a/portal/src/components/game_console/menus/bedroom/BedroomMenu.tsx
+++ b/portal/src/components/game_console/menus/bedroom/BedroomMenu.tsx
@@ -1,5 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
-import MenuLink from '../../lib/MenuLink';
+import MenuPage from '../../lib/MenuPage';
 
 export default function BedroomMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -9,10 +9,5 @@ export default function BedroomMenu() {
     updateMenu('Welcome');
   }
 
-  return (
-    <div>
-      <div>Bedroom</div>
-      <MenuLink onClick={handleBack}>Back</MenuLink>
-    </div>
-  );
+  return <MenuPage title='Bedroom' onBack={handleBack}></MenuPage>;
 }

--- a/portal/src/components/game_console/menus/dojo/DojoMenu.tsx
+++ b/portal/src/components/game_console/menus/dojo/DojoMenu.tsx
@@ -1,5 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
-import MenuLink from '../../lib/MenuLink';
+import MenuPage from '../../lib/MenuPage';
 
 export default function DojoMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -9,10 +9,5 @@ export default function DojoMenu() {
     updateMenu('Welcome');
   }
 
-  return (
-    <div>
-      <div>Dojo</div>
-      <MenuLink onClick={handleBack}>Back</MenuLink>
-    </div>
-  );
+  return <MenuPage title='Dojo' onBack={handleBack}></MenuPage>;
 }

--- a/portal/src/components/game_console/menus/dojo/DojoMenu.tsx
+++ b/portal/src/components/game_console/menus/dojo/DojoMenu.tsx
@@ -1,4 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
+import MenuLink from '../../lib/MenuLink';
 
 export default function DojoMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -11,9 +12,7 @@ export default function DojoMenu() {
   return (
     <div>
       <div>Dojo</div>
-      <div className='cursor-pointer' onClick={handleBack}>
-        Back
-      </div>
+      <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );
 }

--- a/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { FaPlay } from 'react-icons/fa';
 import useScreenStore from '@/stores/screenStore';
 import { Menu } from '@/types/gameConsole';
 import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
 import MenuLink from '../../lib/MenuLink';
-// import usePreviousScreen from '@/hooks/usePreviousScreen';
+import MenuList from '../../lib/MenuList';
 
 const menuItems: { label: string; menu: Menu }[] = [
   { label: 'Players', menu: 'All Players' },
@@ -19,7 +19,7 @@ export default function LaboratoryMenu() {
     if (UpKeys.includes(event.key) && cursorLoc > 0) {
       setCursor((cursorLoc) => cursorLoc - 1);
     }
-    if (DownKeys.includes(event.key) && cursorLoc < 4) {
+    if (DownKeys.includes(event.key) && cursorLoc < 1) {
       setCursor((cursorLoc) => cursorLoc + 1);
     }
     if (ForwardKeys.includes(event.key)) {
@@ -40,18 +40,18 @@ export default function LaboratoryMenu() {
   }
 
   return (
-    <div className='flex flex-col h-full w-full items-center'>
+    <div>
       <div>Laboratory</div>
-      <ul>
-        {menuItems.map((item, i) => (
-          <li key={item.label} tabIndex={-1} id={'select'}>
-            <div className='flex pt-1 items-center text-xs'>
-              {cursorLoc === i ? <FaPlay className='mr-2' /> : null}
-              <span onClick={() => updateMenu(item.menu)}>{item.label}</span>
-            </div>
-          </li>
+
+      <MenuList>
+        {menuItems.map((item) => (
+          <Fragment key={item.label}>
+            <MenuLink onClick={() => updateMenu(item.menu)}>
+              {item.label}
+            </MenuLink>
+          </Fragment>
         ))}
-      </ul>
+      </MenuList>
       <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );

--- a/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, Fragment } from 'react';
-import { FaPlay } from 'react-icons/fa';
 import useScreenStore from '@/stores/screenStore';
 import { Menu } from '@/types/gameConsole';
 import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
 import MenuLink from '../../lib/MenuLink';
 import MenuList from '../../lib/MenuList';
+import MenuPage from '../../lib/MenuPage';
 
 const menuItems: { label: string; menu: Menu }[] = [
   { label: 'Players', menu: 'All Players' },
@@ -40,9 +40,7 @@ export default function LaboratoryMenu() {
   }
 
   return (
-    <div>
-      <div>Laboratory</div>
-
+    <MenuPage title='Laboratory' onBack={handleBack}>
       <MenuList>
         {menuItems.map((item) => (
           <Fragment key={item.label}>
@@ -53,6 +51,6 @@ export default function LaboratoryMenu() {
         ))}
       </MenuList>
       <MenuLink onClick={handleBack}>Back</MenuLink>
-    </div>
+    </MenuPage>
   );
 }

--- a/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
@@ -3,6 +3,7 @@ import { FaPlay } from 'react-icons/fa';
 import useScreenStore from '@/stores/screenStore';
 import { Menu } from '@/types/gameConsole';
 import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
+import MenuLink from '../../lib/MenuLink';
 // import usePreviousScreen from '@/hooks/usePreviousScreen';
 
 const menuItems: { label: string; menu: Menu }[] = [
@@ -51,9 +52,7 @@ export default function LaboratoryMenu() {
           </li>
         ))}
       </ul>
-      <div className='cursor-pointer' onClick={handleBack}>
-        Back
-      </div>
+      <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );
 }

--- a/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
@@ -4,6 +4,7 @@ import { DetailsRes } from '@/types/endpoints/players';
 import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
 import { useEffect, useState } from 'react';
 import { FaPlay } from 'react-icons/fa';
+import MenuLink from '../../lib/MenuLink';
 
 export default function PlayersMenu() {
   const [cursorLoc, setCursor] = useState(0);
@@ -70,9 +71,7 @@ export default function PlayersMenu() {
           </span>
         </div>
       ))}
-      <div className='cursor-pointer' onClick={handleBack}>
-        Back
-      </div>
+      <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );
 }

--- a/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
@@ -3,7 +3,6 @@ import useScreenStore from '@/stores/screenStore';
 import { DetailsRes } from '@/types/endpoints/players';
 import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
 import { useEffect, useState } from 'react';
-import { FaPlay } from 'react-icons/fa';
 import MenuLink from '../../lib/MenuLink';
 import MenuList from '../../lib/MenuList';
 

--- a/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
@@ -5,6 +5,7 @@ import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
 import { useEffect, useState } from 'react';
 import { FaPlay } from 'react-icons/fa';
 import MenuLink from '../../lib/MenuLink';
+import MenuList from '../../lib/MenuList';
 
 export default function PlayersMenu() {
   const [cursorLoc, setCursor] = useState(0);
@@ -45,32 +46,33 @@ export default function PlayersMenu() {
   }
 
   return (
-    <div className='flex flex-wrap py-4 gap-4 w-full'>
+    <div>
       <div>Players</div>
-      {players.map((player, i) => (
-        <div
-          onClick={() => {
-            updatePlayer(players[players.indexOf(player)]);
-            updateMenu('Single Player');
-          }}
-          className='flex items-end h-8 text-xs w-32'
-          key={player.id}
-        >
-          <div className='flex h-full items-center'>
-            {cursorLoc === i ? <FaPlay /> : null}
-          </div>
-          <div className='flex h-12 min-w-[48px]'>
-            <img
-              src={`https://img.pokemondb.net/sprites/black-white/normal/${
-                player.sprite || 'snorlax'
-              }.png`}
-            />
-          </div>
-          <span>
-            {player.first_name} {player.last_name}
-          </span>
-        </div>
-      ))}
+      <div className='py-4'>
+        <MenuList layout='grid'>
+          {players.map((player) => (
+            <div
+              onClick={() => {
+                updatePlayer(players[players.indexOf(player)]);
+                updateMenu('Single Player');
+              }}
+              className='flex items-end h-8 text-xs w-32'
+              key={player.id}
+            >
+              <div className='flex h-12 min-w-[48px]'>
+                <img
+                  src={`https://img.pokemondb.net/sprites/black-white/normal/${
+                    player.sprite || 'snorlax'
+                  }.png`}
+                />
+              </div>
+              <span>
+                {player.first_name} {player.last_name}
+              </span>
+            </div>
+          ))}
+        </MenuList>
+      </div>
       <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );

--- a/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
@@ -51,25 +51,25 @@ export default function PlayersMenu() {
       <div className='py-4'>
         <MenuList layout='grid'>
           {players.map((player) => (
-            <div
+            <MenuLink
               onClick={() => {
                 updatePlayer(players[players.indexOf(player)]);
                 updateMenu('Single Player');
               }}
-              className='flex items-end h-8 text-xs w-32'
               key={player.id}
             >
-              <div className='flex h-12 min-w-[48px]'>
+              <div className='flex h-8 w-32 items-center'>
                 <img
+                  className='h-12 min-w-[48px]'
                   src={`https://img.pokemondb.net/sprites/black-white/normal/${
                     player.sprite || 'snorlax'
                   }.png`}
                 />
+                <span className='text-xs text-left'>
+                  {player.first_name} {player.last_name}
+                </span>
               </div>
-              <span>
-                {player.first_name} {player.last_name}
-              </span>
-            </div>
+            </MenuLink>
           ))}
         </MenuList>
       </div>

--- a/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
@@ -5,6 +5,7 @@ import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
 import { useEffect, useState } from 'react';
 import MenuLink from '../../lib/MenuLink';
 import MenuList from '../../lib/MenuList';
+import MenuPage from '../../lib/MenuPage';
 
 export default function PlayersMenu() {
   const [cursorLoc, setCursor] = useState(0);
@@ -45,8 +46,7 @@ export default function PlayersMenu() {
   }
 
   return (
-    <div>
-      <div>Players</div>
+    <MenuPage title='Players' onBack={handleBack}>
       <div className='py-4'>
         <MenuList layout='grid'>
           {players.map((player) => (
@@ -72,7 +72,6 @@ export default function PlayersMenu() {
           ))}
         </MenuList>
       </div>
-      <MenuLink onClick={handleBack}>Back</MenuLink>
-    </div>
+    </MenuPage>
   );
 }

--- a/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
@@ -1,5 +1,7 @@
 import usePreviousMenu from '@/hooks/usePreviousMenu';
 import useScreenStore from '@/stores/screenStore';
+import MenuPage from '../../lib/MenuPage';
+import MenuList from '../../lib/MenuList';
 
 export default function SinglePlayerMenu() {
   const { player, updateMenu } = useScreenStore();
@@ -8,37 +10,53 @@ export default function SinglePlayerMenu() {
   const sprite = player.sprite || 'snorlax';
 
   return (
-    <div className='flex flex-col text-xs p-2'>
-      <div className='flex items-end h-8 mt-4 pb-4'>
-        <div className='flex h-12'>
-          <img
-            src={`https://img.pokemondb.net/sprites/black-white/normal/${sprite}.png`}
-          />
+    <MenuPage
+      title={
+        <div className='flex items-center'>
+          <div className='flex h-12'>
+            <img
+              src={`https://img.pokemondb.net/sprites/black-white/normal/${sprite}.png`}
+            />
+          </div>
+          <span>
+            {player.first_name} {player.last_name}
+          </span>
         </div>
-        <span className='text-lg'>
-          {player.first_name} {player.last_name}
-        </span>
+      }
+      onBack={() => updateMenu('All Players')}
+    >
+      <div className='text-sm py-2'>
+        <MenuList withCursor={false} itemGap='1'>
+          <div>
+            <div>Sixty Nines</div>
+            <div>{player.six_nine}</div>
+          </div>
+          <div>
+            <div>Quads</div>
+            <div>{player.quads}</div>
+          </div>
+          <div>
+            <div>Total Sessions</div>
+            <div>{player.sessions.length}</div>
+          </div>
+          <div>
+            <div>Cash Net</div>
+            <div>${player.cash_net}</div>
+          </div>
+          <div>
+            <div>Tourney Net</div>
+            <div>${player.tournament_net}</div>
+          </div>
+          <div>
+            <div>Misc Net</div>
+            <div>${player.other_net}</div>
+          </div>
+          <div>
+            <div>Total Net</div>
+            <div>${player.total_net}</div>
+          </div>
+        </MenuList>
       </div>
-      <div>Sixty Nines</div>
-      <div>{player.six_nine}</div>
-      <div>Quads</div>
-      <div>{player.quads}</div>
-      <div>Total Sessions</div>
-      <div>{player.sessions.length}</div>
-      <div>Cash Net</div>
-      <div>${player.cash_net}</div>
-      <div>Tourney Net</div>
-      <div>${player.tournament_net}</div>
-      <div>Misc Net</div>
-      <div>${player.other_net}</div>
-      <div>Total Net</div>
-      <div>${player.total_net}</div>
-      <div
-        className='cursor-pointer text-lg pt-4'
-        onClick={() => updateMenu('All Players')}
-      >
-        Back
-      </div>
-    </div>
+    </MenuPage>
   );
 }

--- a/portal/src/components/game_console/menus/poker_center/PokerCenterMenu.tsx
+++ b/portal/src/components/game_console/menus/poker_center/PokerCenterMenu.tsx
@@ -1,4 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
+import MenuLink from '../../lib/MenuLink';
 
 export default function PokerCenterMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -11,9 +12,7 @@ export default function PokerCenterMenu() {
   return (
     <div>
       <div>Poker Center</div>
-      <div className='cursor-pointer' onClick={handleBack}>
-        Back
-      </div>
+      <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );
 }

--- a/portal/src/components/game_console/menus/poker_center/PokerCenterMenu.tsx
+++ b/portal/src/components/game_console/menus/poker_center/PokerCenterMenu.tsx
@@ -1,5 +1,5 @@
 import useScreenStore from '@/stores/screenStore';
-import MenuLink from '../../lib/MenuLink';
+import MenuPage from '../../lib/MenuPage';
 
 export default function PokerCenterMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -9,10 +9,5 @@ export default function PokerCenterMenu() {
     updateMenu('Welcome');
   }
 
-  return (
-    <div>
-      <div>Poker Center</div>
-      <MenuLink onClick={handleBack}>Back</MenuLink>
-    </div>
-  );
+  return <MenuPage title='Poker Center' onBack={handleBack}></MenuPage>;
 }

--- a/portal/src/components/game_console/menus/poker_mart/PokerMartMenu.tsx
+++ b/portal/src/components/game_console/menus/poker_mart/PokerMartMenu.tsx
@@ -1,5 +1,5 @@
-import usePreviousScreen from '@/hooks/usePreviousScreen';
 import useScreenStore from '@/stores/screenStore';
+import MenuLink from '../../lib/MenuLink';
 
 export default function PokerMartMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -12,9 +12,7 @@ export default function PokerMartMenu() {
   return (
     <div>
       <div>Poker Mart</div>
-      <div className='cursor-pointer' onClick={handleBack}>
-        Back
-      </div>
+      <MenuLink onClick={handleBack}>Back</MenuLink>
     </div>
   );
 }

--- a/portal/src/components/game_console/menus/poker_mart/PokerMartMenu.tsx
+++ b/portal/src/components/game_console/menus/poker_mart/PokerMartMenu.tsx
@@ -1,5 +1,6 @@
 import useScreenStore from '@/stores/screenStore';
 import MenuLink from '../../lib/MenuLink';
+import MenuPage from '../../lib/MenuPage';
 
 export default function PokerMartMenu() {
   const { updateScreen, updateMenu } = useScreenStore();
@@ -9,10 +10,5 @@ export default function PokerMartMenu() {
     updateMenu('Welcome');
   }
 
-  return (
-    <div>
-      <div>Poker Mart</div>
-      <MenuLink onClick={handleBack}>Back</MenuLink>
-    </div>
-  );
+  return <MenuPage title='Poker Mart' onBack={handleBack}></MenuPage>;
 }


### PR DESCRIPTION
We now have a few key library components for our menus. 

- MenuLink
- MenuList
- MenuPage

**MenuLink**
Handles clickable items in the menu screens. Assigns them to have a cursor, and allows for onClick handlers.

```
<MenuLink onClick={() => updateMenu("Welcome")}>
  Link text here
</MenuLink>
```

**MenuList**
Handles the display of data in lists, including optional styling for the `>` cursor. Comes with some layout/spacing props as well to format the list either as a grid or inline list.

```
{/* Inline with spacing between elements */}
<MenuList itemGap='1'>
  <div>item 1</div>
  <div>item 2</div>
</MenuList>

{/* grid */}
<MenuList layout='grid'>
  <div>item 1</div>
  <div>item 2</div>
  ...
  <div>item 11</div>
  <div>item 12</div>
</MenuList>
```

**MenuPage**
General layout for a full page of the menu. For now, it comes baked with `Back` button and expects a title.

```
{/* Basic title */}
<MenuPage title="Player Info" onBack={() => updateMenu("Welcome")}>
  This is my menu text!
</MenuPage>

{/* JSX title */}
<MenuPage 
  title={<MenuLink onClick={...}>Fancy Title</MenuLink>} 
  onBack={() => updateMenu("Welcome")}
>
  This is my menu text!
</MenuPage>
```