### PR TITLE
Cleanup `canvas` logic and add animation pipeline for mouse clicks

### DIFF
--- a/portal/src/components/ui/Canvas.tsx
+++ b/portal/src/components/ui/Canvas.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useRef } from 'react';
-import pokermonMap from '@/assets/pokermon_outside.png';
-import pokerCenter from '@/assets/poker_center.png';
-import cozyShack from '@/assets/bedroom.png';
-import laboratory from '@/assets/laboratory.png';
-import pokerMart from '@/assets/poker_mart.png';
 import useScreenStore from '@/stores/screenStore';
-import { Screen } from '@/types/gameConsole';
 import { Box, ClickableRegion, RegionsByScreen } from './zones';
+import { ScreenInfo, Screens } from './screens';
 
 const mouseClick = {
   x: 0,
@@ -19,58 +14,14 @@ const inBox = (x: number, y: number, box: Box): boolean => {
 
 function draw(
   ctx: CanvasRenderingContext2D,
-  screen: Screen,
+  screenInfo: ScreenInfo,
   regions: ClickableRegion[]
 ) {
   const img = new Image();
-  img.src = pokermonMap;
-  ctx.canvas.width = 1280;
-  ctx.canvas.height = 720;
-  if (screen === 'PokerCenter') {
-    img.src = pokerCenter;
-    ctx.canvas.width = 1024;
-    ctx.canvas.height = 640;
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      ctx.fill();
-    };
-    return;
-  }
-  if (screen === 'Bedroom') {
-    img.src = cozyShack;
-    ctx.canvas.width = 1024;
-    ctx.canvas.height = 640;
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      ctx.fillStyle = `rgba(255, 0,0,0.4)`;
-      regions.forEach((region) => {
-        const { x, y, w, h } = region.box;
-        ctx.fillRect(x, y, w, h);
-      });
-      ctx.fill();
-    };
-    return;
-  }
-  if (screen === 'Laboratory') {
-    img.src = laboratory;
-    ctx.canvas.width = 1024;
-    ctx.canvas.height = 640;
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      ctx.fill();
-    };
-    return;
-  }
-  if (screen === 'PokerMart') {
-    img.src = pokerMart;
-    ctx.canvas.width = 1024;
-    ctx.canvas.height = 640;
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      ctx.fill();
-    };
-    return;
-  }
+  img.src = screenInfo.img;
+  ctx.canvas.width = screenInfo.width;
+  ctx.canvas.height = screenInfo.height;
+
   img.onload = () => {
     ctx.drawImage(img, 0, 0);
     ctx.fillStyle = `rgba(255, 0,0,0.4)`;
@@ -116,7 +67,7 @@ export default function Canvas({ ...props }) {
           updateMenu(region.defaultMenu);
           if (region.screen !== screen) {
             const ctx = canvasRef.current!.getContext('2d')!;
-            draw(ctx, region.screen, RegionsByScreen[region.screen]);
+            draw(ctx, Screens[region.screen], RegionsByScreen[region.screen]);
           }
           break;
         case 'INFO':
@@ -135,7 +86,7 @@ export default function Canvas({ ...props }) {
     if (canvas === null) return;
     const context = canvas.getContext('2d');
     if (context) {
-      draw(context, screen, regions);
+      draw(context, Screens[screen], regions);
     }
 
     function handleCanvasCursor(e: MouseEvent) {

--- a/portal/src/components/ui/Canvas.tsx
+++ b/portal/src/components/ui/Canvas.tsx
@@ -32,6 +32,19 @@ function draw(
   });
 }
 
+function drawClickCircle(ctx: CanvasRenderingContext2D, circle: ClickInfo) {
+  ctx.save();
+  ctx.beginPath();
+  ctx.stroke;
+  ctx.shadowColor = 'white';
+  ctx.shadowBlur = 10;
+  ctx.lineWidth = 2;
+  ctx.arc(circle.x, circle.y, circle.radius, 0, Math.PI * 2);
+  ctx.strokeStyle = `rgba(255,255,255,${circle.alpha})`;
+  ctx.stroke();
+  ctx.restore();
+}
+
 function getCanvasEventPos(
   canvas: HTMLCanvasElement,
   e: MouseEvent
@@ -64,31 +77,20 @@ export default function Canvas({ ...props }) {
     const canvas = canvasRef.current;
     const ctx = canvas!.getContext('2d')!;
 
-    if (screenImageRef.current === undefined) {
-      requestRef.current = requestAnimationFrame(animate);
-      return;
-    }
-
     draw(ctx, Screens[screen], regions, screenImageRef.current!);
 
+    // Stop animating if no click animation,
+    // but, this means we need to request new frames when screen/regions change
     if (clickInfo.current === undefined) {
       return;
     }
 
     const circle = clickInfo.current;
-    ctx.save();
-    ctx.beginPath();
-    ctx.stroke;
-    ctx.shadowColor = 'white';
-    ctx.shadowBlur = 10;
-    ctx.lineWidth = 2;
-    ctx.arc(circle.x, circle.y, circle.radius, 0, Math.PI * 2);
-    ctx.strokeStyle = `rgba(255,255,255,${circle.alpha})`;
-    ctx.stroke();
-    ctx.restore();
+    drawClickCircle(ctx, circle);
 
     circle.radius += 2;
     circle.alpha -= 0.05;
+    // We clear out the graphic once circle grows large enough
     if (circle.radius > 40) {
       clickInfo.current = undefined;
     }
@@ -128,6 +130,7 @@ export default function Canvas({ ...props }) {
             break;
         }
       } else {
+        cancelAnimationFrame(requestRef.current!);
         requestRef.current = requestAnimationFrame(animate);
       }
     };

--- a/portal/src/components/ui/screens.ts
+++ b/portal/src/components/ui/screens.ts
@@ -1,0 +1,57 @@
+import { Screen } from '@/types/gameConsole';
+import pokermonMap from '@/assets/pokermon_outside.png';
+import pokerCenter from '@/assets/poker_center.png';
+import cozyShack from '@/assets/bedroom.png';
+import laboratory from '@/assets/laboratory.png';
+import pokerMart from '@/assets/poker_mart.png';
+
+export type ScreenInfo = {
+  img: string;
+  width: number;
+  height: number;
+};
+
+const WelcomeScreenInfo = {
+  img: pokermonMap,
+  width: 1280,
+  height: 720,
+};
+
+const DojoScreenInfo = {
+  img: '',
+  width: 1024,
+  height: 640,
+};
+
+const BedroomScreenInfo = {
+  img: cozyShack,
+  width: 1024,
+  height: 640,
+};
+
+const LaboratoryScreenInfo = {
+  img: laboratory,
+  width: 1024,
+  height: 640,
+};
+
+const PokerMartScreenInfo = {
+  img: pokerMart,
+  width: 1024,
+  height: 640,
+};
+
+const PokerCenterScreenInfo = {
+  img: pokerCenter,
+  width: 1024,
+  height: 640,
+};
+
+export const Screens: { [key in Screen]: ScreenInfo } = {
+  Welcome: WelcomeScreenInfo,
+  Dojo: DojoScreenInfo,
+  Bedroom: BedroomScreenInfo,
+  Laboratory: LaboratoryScreenInfo,
+  PokerMart: PokerMartScreenInfo,
+  PokerCenter: PokerCenterScreenInfo,
+};

--- a/portal/src/components/ui/screens.ts
+++ b/portal/src/components/ui/screens.ts
@@ -54,4 +54,4 @@ export const Screens: { [key in Screen]: ScreenInfo } = {
   Laboratory: LaboratoryScreenInfo,
   PokerMart: PokerMartScreenInfo,
   PokerCenter: PokerCenterScreenInfo,
-};
+} as const;

--- a/portal/src/components/ui/zones.ts
+++ b/portal/src/components/ui/zones.ts
@@ -56,7 +56,9 @@ const welcomeZones: ClickableRegion[] = [
     box: { x: 1162, y: 28, w: 94, h: 70 },
   },
 ];
+
 const dojoZones: ClickableRegion[] = [];
+
 const bedroomZones: ClickableRegion[] = [
   {
     type: 'INFO',
@@ -64,10 +66,12 @@ const bedroomZones: ClickableRegion[] = [
     box: { x: 510, y: 5, w: 100, h: 55 },
   },
 ];
+
 const laboratoryZones: ClickableRegion[] = [];
+
 const pokerMartZones: ClickableRegion[] = [];
+
 const pokerCenterZones: ClickableRegion[] = [];
-const singlePlayerZones: ClickableRegion[] = [];
 
 export const RegionsByScreen = {
   Welcome: welcomeZones,
@@ -76,5 +80,4 @@ export const RegionsByScreen = {
   Laboratory: laboratoryZones,
   PokerMart: pokerMartZones,
   PokerCenter: pokerCenterZones,
-  SinglePlayer: singlePlayerZones,
 };

--- a/portal/src/components/ui/zones.ts
+++ b/portal/src/components/ui/zones.ts
@@ -80,4 +80,4 @@ export const RegionsByScreen = {
   Laboratory: laboratoryZones,
   PokerMart: pokerMartZones,
   PokerCenter: pokerCenterZones,
-};
+} as const;

--- a/portal/src/types/gameConsole.ts
+++ b/portal/src/types/gameConsole.ts
@@ -4,8 +4,7 @@ export type Screen =
   | 'Bedroom'
   | 'Laboratory'
   | 'PokerMart'
-  | 'PokerCenter'
-  | 'SinglePlayer';
+  | 'PokerCenter';
 
 export type Menu =
   | 'Welcome'


### PR DESCRIPTION
**Screens**
Now we pull screen data from a constant in `screens.ts`. This contains relevant metadata about the canvas screen we will render like image source, width, and height.

Simplifies the `draw` call to now use same logic for all screens based on relevant metadata.

**Mouse Click Animation**
https://github.com/ben-riggles/poker_stats/assets/22751874/a72cb8f9-1b28-468c-b0f7-cbd169c82dad

**RequestAnimationFrame pipeline**
In order to support the mouse clicking, we have added a method `animate` that is used to draw the screen, mouse click graphic, and request another frame. We have some early exit conditions to prevent spamming frame requests when nothing is changing since our app is mostly static at the moment.

Now, if we want to paint to the canvas, we should be calling `requestAnimationFrame(animate)` and storing the result in `requestRef`.