### PR TITLE
Improve data visualization and menus

### DIFF
--- a/portal/src/App.css
+++ b/portal/src/App.css
@@ -28,7 +28,7 @@
 
 .pixel-border {
   border-style: solid;
-  border-width: 2;
+  border-width: 2px;
   border-color: black;
 
   border-image-slice: 4;

--- a/portal/src/App.css
+++ b/portal/src/App.css
@@ -25,3 +25,15 @@
     transform: rotate(360deg);
   }
 }
+
+.pixel-border {
+  border-style: solid;
+  border-width: 2;
+  border-color: black;
+
+  border-image-slice: 4;
+  border-image-width: 2;
+  border-image-outset: 0;
+
+  border-image-source: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12'><path d='M2 2h2v2H2zM4 0h2v2H4zM10 4h2v2h-2zM0 4h2v2H0zM6 0h2v2H6zM8 2h2v2H8zM8 8h2v2H8zM6 10h2v2H6zM0 6h2v2H0zM10 6h2v2h-2zM4 10h2v2H4zM2 8h2v2H2z' fill='000000' /></svg>");
+}

--- a/portal/src/components/game_console/GameMenuSwitch.tsx
+++ b/portal/src/components/game_console/GameMenuSwitch.tsx
@@ -10,6 +10,8 @@ import PokerCenterMenu from './menus/poker_center/PokerCenterMenu';
 import PokerMartMenu from './menus/poker_mart/PokerMartMenu';
 import DojoMenu from './menus/dojo//DojoMenu';
 import BedroomInput from './menus/bedroom/BedroomInput';
+import Leaderboards from './menus/laboratory/Leaderboards';
+import Leaderboard from './menus/laboratory/Leaderboard';
 
 function getMenu(menu: Menu): JSX.Element {
   switch (menu) {
@@ -31,6 +33,10 @@ function getMenu(menu: Menu): JSX.Element {
       return <DojoMenu />;
     case 'Bedroom Input':
       return <BedroomInput />;
+    case 'Leaderboards':
+      return <Leaderboards />;
+    case 'Leaderboard':
+      return <Leaderboard />;
     default:
       return <></>;
   }

--- a/portal/src/components/game_console/lib/MenuList.tsx
+++ b/portal/src/components/game_console/lib/MenuList.tsx
@@ -16,9 +16,8 @@ export default function MenuList({
 }: PropsWithChildren<MenuListProps>) {
   const [cursorPosition, setCursorPosition] = useState(0);
   const gap = itemGap ? `mt-${itemGap}` : '';
-  const columns = window.innerWidth > 768 ? '4' : '2';
-  const containerClasses =
-    layout === 'default' ? '' : `grid grid-cols-${columns} gap-y-4`;
+  const columns = window.innerWidth > 768 ? 'grid-cols-4' : 'grid-cols-2';
+  const containerClasses = layout === 'default' ? '' : `grid ${columns} gap-4`;
 
   useEffect(() => {
     function arrowHandler(event: KeyboardEvent) {

--- a/portal/src/components/game_console/lib/MenuPage.tsx
+++ b/portal/src/components/game_console/lib/MenuPage.tsx
@@ -14,7 +14,7 @@ export default function MenuPage({
   return (
     <div>
       <div>{title}</div>
-      <div>{children}</div>
+      <div className='py-2'>{children}</div>
       <MenuLink onClick={onBack}>Back</MenuLink>
     </div>
   );

--- a/portal/src/components/game_console/lib/MenuProgressBar.tsx
+++ b/portal/src/components/game_console/lib/MenuProgressBar.tsx
@@ -27,13 +27,12 @@ export default function MenuProgressBar({
 }: PropsWithChildren<MenuProgressBarProps>) {
   if (min > max) {
     throw new Error('MenuProgressBar given min value greater than max value');
-  } else if (min === max) {
-    throw new Error('MenuProgressBar given same min and max values');
   }
 
   // Clamp current to [min, max];
   current = Math.max(min, Math.min(current, max));
-  const percentage = (current - min) / (max - min);
+  const range = max - min;
+  const percentage = range === 0 ? 1 : (current - min) / range;
   return (
     <div>
       {title}
@@ -48,9 +47,7 @@ export default function MenuProgressBar({
         </div>
         <div className='w-3 bg-black' />
       </div>
-      <div className='ml-8 text-lg text-center'>
-        {valueRenderer(current)} / {valueRenderer(max)}
-      </div>
+      <div className='ml-8 text-lg text-center'>{valueRenderer(current)}</div>
     </div>
   );
 }

--- a/portal/src/components/game_console/lib/MenuProgressBar.tsx
+++ b/portal/src/components/game_console/lib/MenuProgressBar.tsx
@@ -1,0 +1,56 @@
+import { PropsWithChildren } from 'react';
+
+interface MenuProgressBarProps {
+  title: string;
+  current: number;
+  min?: number;
+  max: number;
+  valueRenderer?: (value: number) => JSX.Element;
+}
+
+function getMeterColor(percentage: number): string {
+  if (percentage > 0.66) {
+    return 'bg-pkmn-green';
+  } else if (percentage > 0.33) {
+    return 'bg-pkmn-orange';
+  } else {
+    return 'bg-pkmn-red';
+  }
+}
+
+export default function MenuProgressBar({
+  title,
+  current,
+  min = 0,
+  max,
+  valueRenderer = (x) => <>{x}</>,
+}: PropsWithChildren<MenuProgressBarProps>) {
+  if (min > max) {
+    throw new Error('MenuProgressBar given min value greater than max value');
+  } else if (min === max) {
+    throw new Error('MenuProgressBar given same min and max values');
+  }
+
+  // Clamp current to [min, max];
+  current = Math.max(min, Math.min(current, max));
+  const percentage = (current - min) / (max - min);
+  return (
+    <div>
+      {title}
+      <div className='flex h-4 mt-1'>
+        <div className=' bg-black text-xs text-orange-200 px-1'>XP:</div>
+        <div className='w-48 h-4'>
+          <div
+            className={`h-2 mt-1 ${getMeterColor(percentage)}`}
+            style={{ width: `${percentage * 100}%` }}
+          ></div>
+          <div className='w-full h-0.5 mt-0.5 bg-black'></div>
+        </div>
+        <div className='w-3 bg-black' />
+      </div>
+      <div className='ml-8 text-lg text-center'>
+        {valueRenderer(current)} / {valueRenderer(max)}
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/LaboratoryMenu.tsx
@@ -1,38 +1,12 @@
-import { useState, useEffect, Fragment } from 'react';
+import { useState, useEffect } from 'react';
 import useScreenStore from '@/stores/screenStore';
-import { Menu } from '@/types/gameConsole';
-import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
+import { DownKeys, UpKeys } from '@/types/keys';
 import MenuLink from '../../lib/MenuLink';
 import MenuList from '../../lib/MenuList';
 import MenuPage from '../../lib/MenuPage';
 
-const menuItems: { label: string; menu: Menu }[] = [
-  { label: 'Players', menu: 'All Players' },
-  { label: 'Exit', menu: 'Welcome' },
-];
-
 export default function LaboratoryMenu() {
-  const [cursorLoc, setCursor] = useState(0);
   const { updateScreen, updateMenu } = useScreenStore();
-
-  function arrowHandler(event: KeyboardEvent) {
-    if (UpKeys.includes(event.key) && cursorLoc > 0) {
-      setCursor((cursorLoc) => cursorLoc - 1);
-    }
-    if (DownKeys.includes(event.key) && cursorLoc < 1) {
-      setCursor((cursorLoc) => cursorLoc + 1);
-    }
-    if (ForwardKeys.includes(event.key)) {
-      updateMenu(menuItems[cursorLoc].menu);
-    }
-  }
-
-  useEffect(() => {
-    window.addEventListener('keydown', arrowHandler);
-    return () => {
-      window.removeEventListener('keydown', arrowHandler);
-    };
-  });
 
   function handleBack() {
     updateScreen('Welcome');
@@ -42,15 +16,11 @@ export default function LaboratoryMenu() {
   return (
     <MenuPage title='Laboratory' onBack={handleBack}>
       <MenuList>
-        {menuItems.map((item) => (
-          <Fragment key={item.label}>
-            <MenuLink onClick={() => updateMenu(item.menu)}>
-              {item.label}
-            </MenuLink>
-          </Fragment>
-        ))}
+        <MenuLink onClick={() => updateMenu('All Players')}>Players</MenuLink>
+        <MenuLink onClick={() => updateMenu('Leaderboards')}>
+          Leaderboards
+        </MenuLink>
       </MenuList>
-      <MenuLink onClick={handleBack}>Back</MenuLink>
     </MenuPage>
   );
 }

--- a/portal/src/components/game_console/menus/laboratory/Leaderboard.tsx
+++ b/portal/src/components/game_console/menus/laboratory/Leaderboard.tsx
@@ -1,0 +1,97 @@
+import useScreenStore from '@/stores/screenStore';
+import MenuPage from '../../lib/MenuPage';
+import {
+  DetailsRes,
+  Leaderboard as LeaderboardType,
+} from '@/types/endpoints/players';
+import { playersApi } from '@/api/allEndpoints';
+import { useEffect, useState } from 'react';
+import MenuList from '../../lib/MenuList';
+import MenuProgressBar from '../../lib/MenuProgressBar';
+import { currency } from './SinglePlayerMenu';
+
+function getTitle(leaderboard: LeaderboardType): string {
+  switch (leaderboard) {
+    case 'six_nine':
+      return `Sixty Nines Leaderboard`;
+    case 'total_net':
+      return `Total Net Leaderboard`;
+    case 'cash_net':
+      return `Cash Net Leaderboard`;
+    case 'tournament_net':
+      return `Tournament Net Leaderboard`;
+    case 'other_net':
+      return `Other Net Leaderboard`;
+    case 'quads':
+      return `Quads Leaderboard`;
+    case 'sessions':
+      return `Sessions Leaderboard`;
+  }
+}
+
+function getLeaderboardValue(
+  player: DetailsRes,
+  type: LeaderboardType
+): number {
+  if (type === 'sessions') {
+    return player.sessions.length;
+  }
+  return player[type];
+}
+
+export default function Leaderboard() {
+  const { updateMenu, leaderboard } = useScreenStore();
+  const [players, setPlayers] = useState<DetailsRes[]>([]);
+
+  useEffect(() => {
+    async function getPlayerDetails() {
+      const res = await playersApi.getAllPlayerDetails();
+      setPlayers(res.data);
+    }
+    getPlayerDetails();
+  }, [setPlayers]);
+
+  if (players.length === 0) {
+    return null;
+  }
+
+  const rankedPlayers = [...players].sort(
+    (a, b) =>
+      getLeaderboardValue(b, leaderboard) - getLeaderboardValue(a, leaderboard)
+  );
+  const topFive = rankedPlayers.slice(0, 5);
+
+  const min = getLeaderboardValue(
+    rankedPlayers[rankedPlayers.length - 1],
+    leaderboard
+  );
+  const max = getLeaderboardValue(rankedPlayers[0], leaderboard);
+  const isCurrencyType = [
+    'total_net',
+    'cash_net',
+    'other_net',
+    'tournament_net',
+  ].includes(leaderboard);
+
+  return (
+    <MenuPage
+      title={getTitle(leaderboard)}
+      onBack={() => updateMenu('Leaderboards')}
+    >
+      <MenuList withCursor={false}>
+        {topFive.map((player, index) => {
+          return (
+            <MenuProgressBar
+              key={player.id}
+              title={`${index + 1}. ${player.first_name} ${player.last_name}`}
+              current={getLeaderboardValue(player, leaderboard)}
+              min={min}
+              max={max}
+              valueRenderer={isCurrencyType ? currency : undefined}
+            />
+          );
+        })}
+      </MenuList>
+    </MenuPage>
+  );
+}

--- a/portal/src/components/game_console/menus/laboratory/Leaderboards.tsx
+++ b/portal/src/components/game_console/menus/laboratory/Leaderboards.tsx
@@ -1,0 +1,44 @@
+import useScreenStore from '@/stores/screenStore';
+import MenuPage from '../../lib/MenuPage';
+import MenuList from '../../lib/MenuList';
+import MenuLink from '../../lib/MenuLink';
+import { Leaderboard } from '@/types/endpoints/players';
+
+export default function Leaderboards() {
+  const { updateMenu, updateLeaderboard } = useScreenStore();
+
+  function handleBack() {
+    updateMenu('Laboratory Menu');
+  }
+
+  function handleLeaderboard(type: Leaderboard) {
+    updateLeaderboard(type);
+    updateMenu('Leaderboard');
+  }
+
+  return (
+    <MenuPage title='Leaderboards' onBack={handleBack}>
+      <MenuList itemGap='1'>
+        <MenuLink onClick={() => handleLeaderboard('six_nine')}>
+          Sixty Nines
+        </MenuLink>
+        <MenuLink onClick={() => handleLeaderboard('quads')}>Quads</MenuLink>
+        <MenuLink onClick={() => handleLeaderboard('sessions')}>
+          Sessions Played
+        </MenuLink>
+        <MenuLink onClick={() => handleLeaderboard('cash_net')}>
+          Cash net
+        </MenuLink>
+        <MenuLink onClick={() => handleLeaderboard('tournament_net')}>
+          Tournament Net
+        </MenuLink>
+        <MenuLink onClick={() => handleLeaderboard('other_net')}>
+          Misc Net
+        </MenuLink>
+        <MenuLink onClick={() => handleLeaderboard('total_net')}>
+          Total net
+        </MenuLink>
+      </MenuList>
+    </MenuPage>
+  );
+}

--- a/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
@@ -10,7 +10,7 @@ import MenuPage from '../../lib/MenuPage';
 export default function PlayersMenu() {
   const [cursorLoc, setCursor] = useState(0);
   const [players, setPlayers] = useState<DetailsRes[]>([]);
-  const { updateScreen, updatePlayer, updateMenu } = useScreenStore();
+  const { updatePlayer, updateMenu } = useScreenStore();
 
   useEffect(() => {
     async function getPlayerDetails() {
@@ -37,13 +37,12 @@ export default function PlayersMenu() {
   });
 
   function handleBack() {
-    updateScreen('Welcome');
-    updateMenu('Welcome');
+    updateMenu('Laboratory Menu');
   }
 
   return (
     <MenuPage title='Players' onBack={handleBack}>
-      <div className='py-4'>
+      <div className='py-2'>
         <MenuList layout='grid'>
           {players.map((player) => (
             <MenuLink

--- a/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/PlayersMenu.tsx
@@ -1,7 +1,7 @@
 import { playersApi } from '@/api/allEndpoints';
 import useScreenStore from '@/stores/screenStore';
 import { DetailsRes } from '@/types/endpoints/players';
-import { DownKeys, ForwardKeys, UpKeys } from '@/types/keys';
+import { DownKeys, UpKeys } from '@/types/keys';
 import { useEffect, useState } from 'react';
 import MenuLink from '../../lib/MenuLink';
 import MenuList from '../../lib/MenuList';
@@ -26,10 +26,6 @@ export default function PlayersMenu() {
     }
     if (DownKeys.includes(event.key) && cursorLoc < players.length - 1) {
       setCursor((cursorLoc) => cursorLoc + 1);
-    }
-    if (ForwardKeys.includes(event.key)) {
-      updatePlayer(players[cursorLoc]);
-      updateScreen('SinglePlayer');
     }
   }
 

--- a/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
@@ -2,6 +2,10 @@ import usePreviousMenu from '@/hooks/usePreviousMenu';
 import useScreenStore from '@/stores/screenStore';
 import MenuPage from '../../lib/MenuPage';
 import MenuList from '../../lib/MenuList';
+import MenuProgressBar from '../../lib/MenuProgressBar';
+
+const Currency = (value: number) =>
+  value > 0 ? <>{`$${value}`}</> : <>{`-$${Math.abs(value)}`}</>;
 
 export default function SinglePlayerMenu() {
   const { player, updateMenu } = useScreenStore();
@@ -27,34 +31,45 @@ export default function SinglePlayerMenu() {
     >
       <div className='text-sm py-2'>
         <MenuList withCursor={false} itemGap='1'>
-          <div>
-            <div>Sixty Nines</div>
-            <div>{player.six_nine}</div>
-          </div>
-          <div>
-            <div>Quads</div>
-            <div>{player.quads}</div>
-          </div>
-          <div>
-            <div>Total Sessions</div>
-            <div>{player.sessions.length}</div>
-          </div>
-          <div>
-            <div>Cash Net</div>
-            <div>${player.cash_net}</div>
-          </div>
-          <div>
-            <div>Tourney Net</div>
-            <div>${player.tournament_net}</div>
-          </div>
-          <div>
-            <div>Misc Net</div>
-            <div>${player.other_net}</div>
-          </div>
-          <div>
-            <div>Total Net</div>
-            <div>${player.total_net}</div>
-          </div>
+          <MenuProgressBar
+            title='Sixty Nines'
+            current={player.six_nine}
+            max={100}
+          />
+          <MenuProgressBar title='Quads' current={player.quads} max={100} />
+          <MenuProgressBar
+            title='Total Sessions'
+            current={player.sessions.length}
+            max={100}
+          />
+          <MenuProgressBar
+            title='Cash Net'
+            current={player.cash_net}
+            min={-250}
+            max={250}
+            valueRenderer={Currency}
+          />
+          <MenuProgressBar
+            title='Tourney Net'
+            current={player.tournament_net}
+            min={-250}
+            max={250}
+            valueRenderer={Currency}
+          />
+          <MenuProgressBar
+            title='Misc Net'
+            current={player.other_net}
+            min={-250}
+            max={250}
+            valueRenderer={Currency}
+          />
+          <MenuProgressBar
+            title='Total Net'
+            current={player.total_net}
+            min={-250}
+            max={250}
+            valueRenderer={Currency}
+          />
         </MenuList>
       </div>
     </MenuPage>

--- a/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
@@ -3,8 +3,8 @@ import useScreenStore from '@/stores/screenStore';
 import MenuPage from '../../lib/MenuPage';
 import MenuList from '../../lib/MenuList';
 
-const currency = (value: number) =>
-  value > 0 ? (
+export const currency = (value: number) =>
+  value >= 0 ? (
     <>{`$${value.toFixed(2)}`}</>
   ) : (
     <>{`-$${Math.abs(value).toFixed(2)}`}</>
@@ -32,7 +32,7 @@ export default function SinglePlayerMenu() {
       }
       onBack={() => updateMenu('All Players')}
     >
-      <div className='text-sm py-2'>
+      <div className='text-sm'>
         <MenuList withCursor={false} layout='grid'>
           <div className='text-center w-full pixel-border p-4'>
             <div className='text-xl'>{player.six_nine}</div>

--- a/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
+++ b/portal/src/components/game_console/menus/laboratory/SinglePlayerMenu.tsx
@@ -2,10 +2,13 @@ import usePreviousMenu from '@/hooks/usePreviousMenu';
 import useScreenStore from '@/stores/screenStore';
 import MenuPage from '../../lib/MenuPage';
 import MenuList from '../../lib/MenuList';
-import MenuProgressBar from '../../lib/MenuProgressBar';
 
-const Currency = (value: number) =>
-  value > 0 ? <>{`$${value}`}</> : <>{`-$${Math.abs(value)}`}</>;
+const currency = (value: number) =>
+  value > 0 ? (
+    <>{`$${value.toFixed(2)}`}</>
+  ) : (
+    <>{`-$${Math.abs(value).toFixed(2)}`}</>
+  );
 
 export default function SinglePlayerMenu() {
   const { player, updateMenu } = useScreenStore();
@@ -30,8 +33,43 @@ export default function SinglePlayerMenu() {
       onBack={() => updateMenu('All Players')}
     >
       <div className='text-sm py-2'>
-        <MenuList withCursor={false} itemGap='1'>
-          <MenuProgressBar
+        <MenuList withCursor={false} layout='grid'>
+          <div className='text-center w-full pixel-border p-4'>
+            <div className='text-xl'>{player.six_nine}</div>
+            <div>Sixty Nines</div>
+          </div>
+
+          <div className='text-center w-full pixel-border p-4'>
+            <div className='text-xl'>{player.quads}</div>
+            <div>Quads</div>
+          </div>
+
+          <div className='text-center w-full pixel-border p-4'>
+            <div className='text-xl'>{player.sessions.length}</div>
+            <div>Total Sessions</div>
+          </div>
+
+          <div className='text-center w-full pixel-border p-4'>
+            <div className='text-xl'>{currency(player.cash_net)}</div>
+            <div>Cash Net</div>
+          </div>
+
+          <div className='text-center w-full pixel-border p-4'>
+            <div className='text-xl'>{currency(player.tournament_net)}</div>
+            <div>Tourney Net</div>
+          </div>
+
+          <div className='text-center w-full pixel-border p-4'>
+            <div className='text-xl'>{currency(player.other_net)}</div>
+            <div>Misc Net</div>
+          </div>
+
+          <div className='text-center w-full pixel-border p-4'>
+            <div className='text-xl'>{currency(player.total_net)}</div>
+            <div>Total Net</div>
+          </div>
+
+          {/* <MenuProgressBar
             title='Sixty Nines'
             current={player.six_nine}
             max={100}
@@ -69,7 +107,7 @@ export default function SinglePlayerMenu() {
             min={-250}
             max={250}
             valueRenderer={Currency}
-          />
+          /> */}
         </MenuList>
       </div>
     </MenuPage>

--- a/portal/src/components/game_console/menus/poker_mart/PokerMartMenu.tsx
+++ b/portal/src/components/game_console/menus/poker_mart/PokerMartMenu.tsx
@@ -1,5 +1,4 @@
 import useScreenStore from '@/stores/screenStore';
-import MenuLink from '../../lib/MenuLink';
 import MenuPage from '../../lib/MenuPage';
 
 export default function PokerMartMenu() {

--- a/portal/src/stores/screenStore.ts
+++ b/portal/src/stores/screenStore.ts
@@ -1,24 +1,28 @@
 import { create } from 'zustand';
 import { Menu, Screen } from '@/types/gameConsole';
 import { AnyObj } from '@/types/generics';
-import { DetailsRes } from '@/types/endpoints/players';
+import { DetailsRes, Leaderboard } from '@/types/endpoints/players';
 
 type ScreenState = {
   screen: Screen;
   menu: Menu;
   player: DetailsRes | AnyObj;
+  leaderboard: Leaderboard;
   updateScreen: (screen: Screen) => void;
   updatePlayer: (player: DetailsRes) => void;
   updateMenu: (menu: Menu) => void;
+  updateLeaderboard: (leaderboard: Leaderboard) => void;
 };
 
 const useScreenStore = create<ScreenState>()((set) => ({
   screen: 'Welcome',
   menu: 'Welcome',
   player: {},
+  leaderboard: 'six_nine',
   updateScreen: (screen: Screen) => set(() => ({ screen })),
   updatePlayer: (player) => set(() => ({ player })),
   updateMenu: (menu: Menu) => set(() => ({ menu })),
+  updateLeaderboard: (leaderboard: Leaderboard) => set(() => ({ leaderboard })),
 }));
 
 export default useScreenStore;

--- a/portal/src/types/endpoints/players.ts
+++ b/portal/src/types/endpoints/players.ts
@@ -35,3 +35,13 @@ export type Sessions = {
   six_nine: number;
   quads: number;
 };
+
+export type Leaderboard =
+  | 'six_nine'
+  | 'total_net'
+  | 'cash_net'
+  | 'tournament_net'
+  | 'other_net'
+  | 'six_nine'
+  | 'quads'
+  | 'sessions';

--- a/portal/src/types/gameConsole.ts
+++ b/portal/src/types/gameConsole.ts
@@ -15,4 +15,6 @@ export type Menu =
   | 'Poker Center Menu'
   | 'Poker Mart Menu'
   | 'Dojo Menu'
-  | 'Bedroom Input';
+  | 'Bedroom Input'
+  | 'Leaderboards'
+  | 'Leaderboard';


### PR DESCRIPTION
**Leaderboards**
<img width="849" alt="image" src="https://github.com/ben-riggles/poker_stats/assets/22751874/015f48c5-b3db-4bfe-aaf2-548d81ad777d">

<img width="891" alt="image" src="https://github.com/ben-riggles/poker_stats/assets/22751874/4a398481-ed18-4bd7-bcc9-caa2134e8939">

**Data wells**
<img width="909" alt="image" src="https://github.com/ben-riggles/poker_stats/assets/22751874/b73959af-abbd-44ac-80c8-9b918021615e">
